### PR TITLE
Fix Docker build paths in service Dockerfiles

### DIFF
--- a/backend/services/api-gateway/Dockerfile
+++ b/backend/services/api-gateway/Dockerfile
@@ -3,18 +3,24 @@ FROM golang:1.20-alpine AS builder
 WORKDIR /app
 
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY backend/go.mod backend/go.mod
+COPY backend/go.sum backend/go.sum
+
+# Set Working Directory for Go Modules
+WORKDIR /app/backend
 
 # Download dependencies
 RUN go mod download
 
+# Go back to root directory
+WORKDIR /app
+
 # Copy the source code
-COPY pkg/ /app/pkg/
-COPY services/api-gateway/ /app/services/api-gateway/
+COPY backend/pkg/ /app/backend/pkg/
+COPY backend/services/api-gateway/ /app/backend/services/api-gateway/
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o api-gateway /app/services/api-gateway/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o api-gateway /app/backend/services/api-gateway/
 
 # Use a smaller image for the final container
 FROM alpine:latest

--- a/backend/services/auth/Dockerfile
+++ b/backend/services/auth/Dockerfile
@@ -3,18 +3,24 @@ FROM golang:1.20-alpine AS builder
 WORKDIR /app
 
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY backend/go.mod backend/go.mod
+COPY backend/go.sum backend/go.sum
+
+# Set Working Directory for Go Modules
+WORKDIR /app/backend
 
 # Download dependencies
 RUN go mod download
 
+# Go back to root directory
+WORKDIR /app
+
 # Copy the source code
-COPY pkg/ /app/pkg/
-COPY services/auth/ /app/services/auth/
+COPY backend/pkg/ /app/backend/pkg/
+COPY backend/services/auth/ /app/backend/services/auth/
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o auth-service /app/services/auth/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o auth-service /app/backend/services/auth/
 
 # Use a smaller image for the final container
 FROM alpine:latest

--- a/backend/services/user/Dockerfile
+++ b/backend/services/user/Dockerfile
@@ -3,18 +3,24 @@ FROM golang:1.20-alpine AS builder
 WORKDIR /app
 
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY backend/go.mod backend/go.mod
+COPY backend/go.sum backend/go.sum
+
+# Set Working Directory for Go Modules
+WORKDIR /app/backend
 
 # Download dependencies
 RUN go mod download
 
+# Go back to root directory
+WORKDIR /app
+
 # Copy the source code
-COPY pkg/ /app/pkg/
-COPY services/user/ /app/services/user/
+COPY backend/pkg/ /app/backend/pkg/
+COPY backend/services/user/ /app/backend/services/user/
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o user-service /app/services/user/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o user-service /app/backend/services/user/
 
 # Use a smaller image for the final container
 FROM alpine:latest


### PR DESCRIPTION
## Fix for Docker Build Failures

This PR fixes the Docker build failures by correcting the file paths in all service Dockerfiles.

### What was the problem?
The Dockerfiles were attempting to copy files from incorrect paths. The error messages indicated that files like `backend/services/auth/` couldn't be found because the Dockerfiles were looking for them at the wrong location.

### What changes were made?
1. Updated paths in all three Dockerfiles (auth-service, user-service, api-gateway) to correctly reference files in the repository structure:
   - Changed `COPY go.mod go.mod` to `COPY backend/go.mod backend/go.mod`
   - Changed `COPY go.sum go.sum` to `COPY backend/go.sum backend/go.sum`
   - Added a proper working directory change to `/app/backend` for go mod download
   - Updated source code copy paths to include the `backend/` prefix
   - Updated build paths to reference the correct files

### How to test?
Run `docker-compose up --build` in the backend directory to verify that all services build and start correctly.
